### PR TITLE
[AT][Search][form] SearchLanguageField_testSearchLanguageField_Happy_<RustamKhudoyarov>

### DIFF
--- a/src/test/java/RustamKhudoyarovTest.java
+++ b/src/test/java/RustamKhudoyarovTest.java
@@ -1,0 +1,29 @@
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import runner.BaseTest;
+import java.util.List;
+
+public class RustamKhudoyarovTest extends BaseTest {
+
+        @Test
+        public void testSearchLanguageField_HappyPath(){
+                final String BASE_URL = "https://www.99-bottles-of-beer.net/";
+                final String LANGUAGE_PYTHON = "python";
+
+                getDriver().get(BASE_URL);
+
+                getDriver().findElement(By.xpath("//ul[@id ='menu']/li/a[@href ='/search.html']")).click();
+                getDriver().findElement(By.xpath("//input[@name ='search']")).sendKeys(LANGUAGE_PYTHON);
+                getDriver().findElement(By.xpath("//input[@name ='submitsearch']")).click();
+
+                List<WebElement> languagesNameList = getDriver().findElements(By.xpath("//table[@id='category']/tbody/tr/td[1]/a"));
+
+                Assert.assertTrue(languagesNameList.size()>0);
+                for (WebElement l : languagesNameList) {
+                      Assert.assertTrue(l.getText().toLowerCase().contains(LANGUAGE_PYTHON));
+                }
+        }
+
+}


### PR DESCRIPTION
Added test testSearchLanguageField_HappyPath()
[US] - https://trello.com/c/eAkTmbtI/92-usfunctionalsearchform-search-for-language-field
[TC] - https://trello.com/c/Lofw9Uao/89-tcsearchform-verify-if-user-is-searching-for-programming-language-by-name-he-can-see-the-list-of-relative-results-rustamkhudoyar
[AT] - https://trello.com/c/uBZApyhV/116-atsearchform-testsearchlanguagefieldhappyrustamkhudoyarov