### PR TITLE
[AT][Search][form] testSearchForLanguageByName_HappyPath() <ElenaStrat>

### DIFF
--- a/src/test/java/ElenaStratTest.java
+++ b/src/test/java/ElenaStratTest.java
@@ -1,0 +1,36 @@
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import runner.BaseTest;
+
+import java.util.List;
+
+public class ElenaStratTest extends BaseTest {
+    static final String BASE_URL = "https://www.99-bottles-of-beer.net/";
+
+    @Test
+    public void testSearchForLanguageByName_HappyPath() {
+        final String LANGUAGE_PYTHON = "python";
+
+        getDriver().get(BASE_URL);
+
+        WebElement searchLanguagesMenu = getDriver().findElement(By.xpath("//ul[@id = 'menu']/li/a[@href = '/search.html']")
+        );
+        searchLanguagesMenu.click();
+
+        WebElement searchForField = getDriver().findElement(By.name("search"));
+        searchForField.click();
+        searchForField.sendKeys(LANGUAGE_PYTHON);
+
+        WebElement goButton = getDriver().findElement(By.name("submitsearch"));
+        goButton.click();
+
+        List<WebElement> languagesNamesList = getDriver().findElements(By.xpath("//table[@id='category']/tbody/tr/td[1]/a"));
+
+        Assert.assertTrue(languagesNamesList.size() > 0);
+        for (int i = 0; i < languagesNamesList.size(); i++) {
+            Assert.assertTrue(languagesNamesList.get(i).getText().toLowerCase().contains(LANGUAGE_PYTHON));
+        }
+    }
+}


### PR DESCRIPTION
testSearchForLanguageByName_HappyPath() added

[US] https://trello.com/c/nFQtJ2G5/14-usfunctionalsearchform-search-for-language-field
[TC] https://trello.com/c/xGHPyLSR/62-tcstartform-verify-if-user-is-searching-for-programming-language-by-name-he-can-see-the-list-of-relative-results-elenastrat
[AT] https://trello.com/c/sNeSIta2/103-atsearchform-testsearchforlanguagebynamehappypath-elenastrat
