### PR TITLE
[AT][Search][form] testSearchForLanguageByName_HappyPath() <NataliiaOliver>

### DIFF
--- a/src/test/java/NataliiaOliverTest.java
+++ b/src/test/java/NataliiaOliverTest.java
@@ -1,0 +1,39 @@
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import runner.BaseTest;
+
+import java.util.List;
+
+public class NataliiaOliverTest extends BaseTest {
+
+    static final String BASE_URL = "https://www.99-bottles-of-beer.net/";
+
+    @Test
+    public void testSearchForLanguageByName_HappyPath() {
+        final String LANGUAGE_NAME = "python";
+
+        getDriver().get(BASE_URL);
+
+        WebElement searchLanguagesMenu = getDriver().findElement(
+                By.xpath("//ul[@id='menu']/li/a[@href='/search.html']"));
+        searchLanguagesMenu.click();
+
+        WebElement searchForField = getDriver().findElement(By.name("search"));
+        searchForField.click();
+        searchForField.sendKeys(LANGUAGE_NAME);
+
+        WebElement goButton = getDriver().findElement(By.name("submitsearch"));
+        goButton.click();
+
+        List<WebElement> languageNamesList = getDriver().findElements(
+                By.xpath("//table[@id='category']/tbody/tr/td[1]/a"));
+
+        Assert.assertTrue(languageNamesList.size() > 0);
+
+        for (int i = 0; i < languageNamesList.size(); i++) {
+            Assert.assertTrue(languageNamesList.get(i).getText().toLowerCase().contains(LANGUAGE_NAME));
+        }
+    }
+}


### PR DESCRIPTION
testSearchForLanguageByName_HappyPath() added

[US] - https://trello.com/c/9AT5KvuL/22-usfunctionalsearchform-search-for-language-field
[TC] - https://trello.com/c/BbGI3hD0/65-tcsearchform-verify-if-user-is-searching-for-programming-language-by-name-he-can-see-the-list-of-relative-results-nataliiaoliver
[AT] - https://trello.com/c/pmCYqoD2/96-atsearchform-testsearchforlanguagebynamehappypath-nataliiaoliver