### PR TITLE
[AT][Search][form] testSearchLanguageByName_HappyPath() <Enmedv>

### DIFF
--- a/src/test/java/EnmedvTest.java
+++ b/src/test/java/EnmedvTest.java
@@ -1,0 +1,37 @@
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import runner.BaseTest;
+import java.util.List;
+
+public class EnmedvTest extends BaseTest {
+    static final String BASE_URL = "https://www.99-bottles-of-beer.net/";
+
+    @Test
+    public void testSearchLanguageByName_HappyPath() {
+        final String LANGUAGE_PYTHON = "python";
+
+        getDriver().get(BASE_URL);
+        WebElement SearchLanguagesMenu = getDriver().findElement(
+                By.xpath("//ul[@id = 'menu']/li/a[@href = '/search.html']")
+                );
+        SearchLanguagesMenu.click();
+
+        WebElement searchForField = getDriver().findElement(By.name("search"));
+        searchForField.click();
+        searchForField.sendKeys(LANGUAGE_PYTHON);
+
+        WebElement goButton = getDriver().findElement(By.name("submitsearch"));
+        goButton.click();
+
+        List<WebElement> languagesNamesList = getDriver().findElements(
+                By.xpath("//table[@id = 'category']/tbody/tr/td[1]/a")
+        );
+        Assert.assertTrue(languagesNamesList.size() > 0);
+
+        for (int i = 0; i < languagesNamesList.size(); i ++) {
+            Assert.assertTrue(languagesNamesList.get(i).getText().toLowerCase().contains(LANGUAGE_PYTHON));
+        }
+    }
+}


### PR DESCRIPTION
testSearchLanguageByName_HappyPath() added

[US] - https://trello.com/c/mlPkPJV3/40-usfunctionalsearchform-search-for-language-field
[TC] - https://trello.com/c/DIZa4n9E/69-tcsearchform-verify-if-user-is-searching-for-programming-language-by-name-he-can-see-the-list-of-relative-results-enmedv
[AT] - https://trello.com/c/8YP3L9AM/109-atsearchform-testsearchlanguagebynamehappypath-enmedv

