### PR TITLE
[AT][Search][form] testSearchForLanguageByName_HappyPath <julykan>

### DIFF
--- a/src/test/java/JulykanTest.java
+++ b/src/test/java/JulykanTest.java
@@ -1,0 +1,39 @@
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import runner.BaseTest;
+
+import java.util.List;
+
+
+public class JulykanTest extends BaseTest {
+    @Test
+    public void testSearchForLanguageByName_HappyPath() {
+        final String BASE_URL = "https://www.99-bottles-of-beer.net/";
+        final String LANGUAGE_PYTHON = "python";
+
+        getDriver().get(BASE_URL);
+
+        WebElement searchLanguagesMenu = getDriver().findElement(
+                By.xpath("//ul[@id='menu']/li/a[@href='/search.html']"));
+        searchLanguagesMenu.click();
+
+        WebElement searchForField = getDriver().findElement(By.name("search"));
+        searchForField.click();
+        searchForField.sendKeys(LANGUAGE_PYTHON);
+
+        WebElement goButton = getDriver().findElement(By.name("submitsearch"));
+        goButton.click();
+
+        List<WebElement> languagesNamesList = getDriver().findElements(
+                By.xpath("//table[@id='category']/tbody/tr/td[1]/a"));
+
+        Assert.assertTrue(languagesNamesList.size() > 0);
+
+        for (int i = 0; i < languagesNamesList.size(); i++) {
+            Assert.assertTrue(languagesNamesList.get(i).getText().toLowerCase().contains(LANGUAGE_PYTHON));
+        }
+    }
+}
+


### PR DESCRIPTION
 testSearchForLanguageByName_HappyPath
[US]https://trello.com/c/Yp7L6BKo/52-usfunctionalsearchform-search-for-language-field
[TC]https://trello.com/c/naPjrOji/58-tcsearchform-verify-if-user-is-searching-for-programming-language-by-name-he-can-see-the-list-of-relative-results-julykan
[AT]https://trello.com/c/5UoOOe6E/119-atsearchform-testsearchforlanguagebynamehappypath-julykan
