### PR TITLE
[AT][Search][form] testSearchForLanguageByName_HappyPath() <JulieMyk>

### DIFF
--- a/src/test/java/JulieMykTest.java
+++ b/src/test/java/JulieMykTest.java
@@ -1,0 +1,37 @@
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import runner.BaseTest;
+
+import java.util.List;
+
+public class JulieMykTest extends BaseTest {
+
+    @Test
+    public void testSearchForLanguageByName_HappyPath() {
+        final String BASE_URL = "https://www.99-bottles-of-beer.net/";
+        final String LANGUAGE_PYTHON = "python";
+        getDriver().get(BASE_URL);
+
+        WebElement searchLanguagesMenu = getDriver().findElement(
+                By.xpath("//ul[@id = 'menu']/li/a[@href = '/search.html']"));
+        searchLanguagesMenu.click();
+
+        WebElement searchForField = getDriver().findElement(By.name("search"));
+        searchForField.click();
+        searchForField.sendKeys(LANGUAGE_PYTHON);
+
+        WebElement goButton = getDriver().findElement(By.name("submitsearch"));
+        goButton.click();
+
+        List<WebElement> languagesNamesList = getDriver().findElements
+                (By.xpath("//table[@id='category']/tbody/tr/td[1]/a"));
+
+        Assert.assertTrue(languagesNamesList.size() > 0);
+
+        for (int i = 0; i < languagesNamesList.size(); i++) {
+            Assert.assertTrue(languagesNamesList.get(i).getText().toLowerCase().contains(LANGUAGE_PYTHON));
+        }
+    }
+}


### PR DESCRIPTION
testSearchForLanguageByName_HappyPath() added

[US] - https://trello.com/c/eVTF1feF/31-usfunctionalsearchform-search-for-language-field
[AT] - https://trello.com/c/ucKUevgO/100-atsearchform-testsearchforlanguagebynamehappypathjuliemyk
[TC] - https://trello.com/c/zbjlwIGy/66-tcsearchform-verify-if-searching-for-programming-language-by-name-he-can-see-the-list-of-related-results-juliemyk

