### PR TITLE
[AT][Search][form] testSearchLanguageByName_HappyPath() <SvetaKhudova>

### DIFF
--- a/src/test/java/SvetaKhudovaTest.java
+++ b/src/test/java/SvetaKhudovaTest.java
@@ -1,0 +1,38 @@
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import runner.BaseTest;
+
+import java.util.List;
+
+public class SvetaKhudovaTest extends BaseTest {
+    static final String BASE_URL = "https://www.99-bottles-of-beer.net/";
+
+    @Test
+    public void testSearchLanguageByName_HappyPath(){
+        final String LANGUAGE_NAME = "python";
+
+        getDriver().get(BASE_URL);
+
+        WebElement searchLanguagesMenu = getDriver().findElement(
+                By.xpath("//ul[@id = 'menu']/li/a[@href = '/search.html']")
+        );
+        searchLanguagesMenu.click();
+
+        WebElement searchForField = getDriver().findElement(By.name("search"));
+        searchForField.click();
+        searchForField.sendKeys(LANGUAGE_NAME);
+
+        WebElement goButton = getDriver().findElement(By.name("submitsearch"));
+        goButton.click();
+
+        List<WebElement> languagesNamesList = getDriver().findElements(By.xpath("//table[@id='category']/tbody/tr/td[1]/a"));
+
+        Assert.assertTrue(languagesNamesList.size() > 0);
+
+        for (int i = 0; i < languagesNamesList.size(); i++) {
+            Assert.assertTrue(languagesNamesList.get(i).getText().toLowerCase().contains(LANGUAGE_NAME));
+        }
+    }
+}


### PR DESCRIPTION
testSearchLanguageByName_HappyPath added

[US] - https://trello.com/c/GRtgfi9k/45-usfunctionalsearch-search-for-language-field
[TC] - https://trello.com/c/aRjytWzM/77-tcsearchform-verify-if-user-is-searching-for-programming-language-by-name-he-can-see-the-list-of-relative-results-svetakhudova
[AT] https://trello.com/c/pzc8J67U/106-atsearchform-testsearchlanguagebynamehappypath-svetakhudova