### PR TITLE
[AT][Search][form]testSearchLanguageFieldByName_HappyPath<NatalyaYanochkova>

### DIFF
--- a/src/test/java/NatalyaYanochkovaTest.java
+++ b/src/test/java/NatalyaYanochkovaTest.java
@@ -1,0 +1,38 @@
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import runner.BaseTest;
+
+import java.util.Collections;
+import java.util.List;
+
+public class NatalyaYanochkovaTest extends BaseTest{
+    @Test
+    public void testSearchLanguageFieldByName_HappyPath(){
+        final String BASE_URL = "https://www.99-bottles-of-beer.net/";
+        final String Language_Python = "python";
+
+        getDriver().get(BASE_URL);
+        WebElement searchLanguagesMenu = getDriver().findElement(
+                By.xpath("//*[@id=\"menu\"]/li[3]/a")
+        );
+        searchLanguagesMenu.click();
+
+        WebElement searchForField = getDriver().findElement(By.name("search"));
+        searchForField.click();
+        searchForField.sendKeys(Language_Python);
+
+        WebElement goButton = getDriver().findElement(By.name("submitsearch"));
+        goButton.click();
+
+        List<WebElement> languagesNameList = Collections.singletonList(getDriver().findElement(
+                By.xpath("//table[@id='category']/tbody/tr/td[1]/a")));
+
+        Assert.assertTrue(languagesNameList.size()>0);
+
+        for(int i=0; i<languagesNameList.size(); i++){
+            Assert.assertTrue(languagesNameList.get(i).getText().toLowerCase().contains(Language_Python));
+        }
+    }
+}


### PR DESCRIPTION
testSearchLanguageFieldByName_HappyPath() added
[US][](https://trello.com/c/MJVRAwtT/124-usfunctionalsearchform-search-for-language-field)
[TC][](https://trello.com/c/FhCO8sqe/125-tcsearchformnatalyayanochkova-verify-if-user-is-searching-for-a-programming-language-by-name-he-can-see-the-list-of-relative-res)
[AT][](https://trello.com/c/uBIJTTUR/123-atsearchformtestsearchlanguagefieldbynamehappypathnatalyayanochkova)