### PR TITLE
[AT][Search][form] testSearchLanguageByName_HappyPath() <verafes>

### DIFF
--- a/src/test/java/VerafesTest.java
+++ b/src/test/java/VerafesTest.java
@@ -1,5 +1,6 @@
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 import runner.BaseTest;
 
@@ -8,8 +9,7 @@ import java.util.List;
 public class VerafesTest extends BaseTest {
 
     @Test
-    public void testSearchLanguageField_HappyPath() {
-
+    public void testSearchForLanguageByName_HappyPath() {
         final String BASE_URL = "https://www.99-bottles-of-beer.net/";
         final String LANGUAGE_NAME = "python";
 
@@ -29,5 +29,10 @@ public class VerafesTest extends BaseTest {
 
         List<WebElement> languagesNamesList = getDriver().findElements(By.xpath("//table[@id='category']/tbody/tr/td[1]/a"));
 
+        Assert.assertTrue(languagesNamesList.size() > 0);
+
+        for (int i = 0; i < languagesNamesList.size(); i++) {
+            Assert.assertTrue(languagesNamesList.get(i).getText().toLowerCase().contains(LANGUAGE_NAME));
+        }
     }
 }

--- a/src/test/java/VerafesTest.java
+++ b/src/test/java/VerafesTest.java
@@ -1,0 +1,33 @@
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.testng.annotations.Test;
+import runner.BaseTest;
+
+import java.util.List;
+
+public class VerafesTest extends BaseTest {
+
+    @Test
+    public void testSearchLanguageField_HappyPath() {
+
+        final String BASE_URL = "https://www.99-bottles-of-beer.net/";
+        final String LANGUAGE_NAME = "python";
+
+        getDriver().get(BASE_URL);
+
+        WebElement searchLanguagesMenu = getDriver().findElement(
+                By.xpath("//ul[@id = 'menu']/li/a[@href = '/search.html']")
+        );
+        searchLanguagesMenu.click();
+
+        WebElement searchForField = getDriver().findElement(By.name("search"));
+        searchForField.click();
+        searchForField.sendKeys(LANGUAGE_NAME);
+
+        WebElement goButton = getDriver().findElement(By.name("submitsearch"));
+        goButton.click();
+
+        List<WebElement> languagesNamesList = getDriver().findElements(By.xpath("//table[@id='category']/tbody/tr/td[1]/a"));
+
+    }
+}


### PR DESCRIPTION
testSearchLanguageByName_HappyPath added
[US] - https://trello.com/c/GRtgfi9k/45-usfunctionalsearch-search-for-language-field 
[TC] - https://trello.com/c/7Op5mHP4/132-tcsearchform-verify-if-user-is-searching-for-programming-language-by-name-he-can-see-the-list-of-relative-results-verafes
[AT] - https://trello.com/c/Ld6ePLq6/133-atsearchform-testsearchforlanguagebynamehappypath-verafes
