### PR TITLE
[AT][Search][form] testSearchForLanguageByName_HappyPath()<Albina-star>

### DIFF
--- a/src/test/java/Albina_starTest.java
+++ b/src/test/java/Albina_starTest.java
@@ -1,0 +1,38 @@
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import runner.BaseTest;
+
+import java.util.List;
+
+public class Albina_starTest extends BaseTest {
+
+    @Test
+    public void testSearchForLanguageByName_HappyPath(){
+        final String BASE_URL = "https://99-bottles-of-beer.net/";
+        final String LANGUAGE_PYTHON = "python";
+
+        getDriver().get(BASE_URL);
+
+        WebElement searchLanguagesMenu = getDriver().findElement(
+                By.xpath("//ul[@id = 'menu']/li/a[@href = '/search.html']"));
+        searchLanguagesMenu.click();
+
+        WebElement searchForField = getDriver().findElement(By.name("search"));
+        searchForField.click();
+        searchForField.sendKeys(LANGUAGE_PYTHON);
+
+        WebElement goButton = getDriver().findElement(By.name("submitsearch"));
+        goButton.click();
+
+        List<WebElement> languagesNamesList = getDriver().findElements(
+                By.xpath("//table[@id='category']/tbody/tr/td[1]/a"));
+
+        Assert.assertTrue(languagesNamesList.size() > 0);
+
+        for (int i = 0; i < languagesNamesList.size(); i++) {
+            Assert.assertTrue(languagesNamesList.get(i).getText().toLowerCase().contains(LANGUAGE_PYTHON));
+        }
+    }
+}


### PR DESCRIPTION
testSearchForLanguageByName_HappyPath() added

[US] - https://trello.com/c/hPoy7MDv/21-usfunctionalsearchform-search-for-language-field
[TC] - https://trello.com/c/eSYlTy4f/83-tcstartform-verify-if-user-is-searching-for-programming-language-by-name-he-can-see-the-list-of-relative-results-albina-star
[AT] - https://trello.com/c/ZNenlYV3/111-atsearchform-testsearchforlanguagebynamehappypathalbina-star 
