### PR TITLE
[AT][Search][form] testSearchForLanguageByName_HappyPath() <VictoriaLema>

### DIFF
--- a/src/test/java/VictoriaLemaTest.java
+++ b/src/test/java/VictoriaLemaTest.java
@@ -1,0 +1,40 @@
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import runner.BaseTest;
+
+import java.util.List;
+
+public class VictoriaLemaTest extends BaseTest {
+
+    static final String BASE_URL = "https://www.99-bottles-of-beer.net/";
+    @Test
+    public void testSearchForLanguageByName_HappyPath() {
+        final String LANGUAGE_NAME = "python";
+
+        getDriver().get(BASE_URL);
+
+        WebElement searchLanguagesMenu = getDriver().findElement(
+                By.xpath("//ul[@id='menu']/li/a[@href = '/search.html']")
+        );
+        searchLanguagesMenu.click();
+
+        WebElement searchForField = getDriver().findElement(By.name("search"));
+        searchForField.click();
+        searchForField.sendKeys(LANGUAGE_NAME);
+
+        WebElement goButton = getDriver().findElement(By.name("submitsearch"));
+        goButton.click();
+
+        List<WebElement> languagesNameList = getDriver().findElements(
+                By.xpath("//table[@id='category']/tbody/tr/td[1]/a")
+        );
+
+        Assert.assertTrue(languagesNameList.size() > 0);
+
+        for (int i = 0; i < languagesNameList.size(); i++){
+            Assert.assertTrue(languagesNameList.get(i).getText().toLowerCase().contains(LANGUAGE_NAME));
+        }
+    }
+}


### PR DESCRIPTION
testSearchForLanguageByName_HappyPath() added

[US] - https://trello.com/c/BF2kTwGt/163-usfunctionalsearchform-search-for-language-field-victorialema
[TC] - https://trello.com/c/g8PfQpCz/80-tcsearchform-verify-if-user-is-searching-for-a-programming-language-by-name-he-can-see-the-list-of-relative-resultsvictorialema
[AT] - https://trello.com/c/4wPyIuVv/99-atsearchform-testsearchforlanguagebynamehappypath-victorialema