### PR TITLE
[AT][Functional][Search][form] testSearchForLanguageByName_HappyPath() <AnaLara>

### DIFF
--- a/src/test/java/AnaLaraTest.java
+++ b/src/test/java/AnaLaraTest.java
@@ -1,0 +1,40 @@
+import org.apache.commons.codec.language.bm.Lang;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import runner.BaseTest;
+
+import java.util.List;
+
+public class AnaLaraTest extends BaseTest {
+
+    @Test
+    public void testSearchLanguageField_HappyPath() {
+
+        final String BASE_URL = "https://www.99-bottles-of-beer.net/";
+        final String LANGUAGE_NAME = "python";
+
+        getDriver().get(BASE_URL);
+
+        WebElement searchLanguagesMenu = getDriver().findElement(By.xpath("//ul[@id='menu']/li/a[@href = '/search.html']")
+        );
+        searchLanguagesMenu.click();
+
+        WebElement searchForField = getDriver().findElement(By.name("search"));
+        searchForField.click();
+        searchForField.sendKeys(LANGUAGE_NAME);
+
+        WebElement goButton = getDriver().findElement(By.name("submitsearch"));
+        goButton.click();
+
+        List<WebElement> languagesNamesList = getDriver().findElements(
+                By.xpath("//table[@id = 'category']/tbody/tr/td[1]/a")
+        );
+        Assert.assertTrue(languagesNamesList.size() > 0);
+
+        for (int i = 0; i < languagesNamesList.size(); i ++) {
+            Assert.assertTrue(languagesNamesList.get(i).getText().toLowerCase().contains(LANGUAGE_NAME));
+        }
+    }
+}


### PR DESCRIPTION
testSearchLanguageField_HappyPath added

[US] https://trello.com/c/Pfi21TZq/49-usfunctionalsearchform-search-for-language-feild
[TC] https://trello.com/c/NSs9ExK4/255-tcsearchform-verify-if-user-is-searching-for-programming-language-by-name-and-can-see-the-list-of-relative-results-analara
[AT] https://trello.com/c/z0h5ZbRP/257-atsearchform-testsearchforlanguagebynamehappypath-analara 