### PR TITLE
[AT][Search][form] testSearchForLanguageFieldByName_HappyPath() <AndreiMironau>

### DIFF
--- a/src/test/java/AndreiMironauTest.java
+++ b/src/test/java/AndreiMironauTest.java
@@ -1,0 +1,43 @@
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import runner.BaseTest;
+
+import java.util.List;
+
+public class AndreiMironauTest extends BaseTest {
+
+    @Test
+    public void testSearchForLanguageFieldByName_HappyPath() {
+        //A1
+        final String BASE_URL = "https://www.99-bottles-of-beer.net/";
+        final String LANGUAGE_PYTHON = "python";
+
+        //A2
+        getDriver().get(BASE_URL);
+
+        WebElement searchLanguagesMenu = getDriver().findElement(
+                By.xpath("//ul[@id = 'menu']/li/a[@href = '/search.html']")
+        );
+        searchLanguagesMenu.click();
+
+        WebElement searchForField = getDriver().findElement(By.name("search"));
+        searchForField.click();
+        searchForField.sendKeys(LANGUAGE_PYTHON);
+
+        WebElement goButton = getDriver().findElement(By.name("submitsearch"));
+        goButton.click();
+
+        List<WebElement> languagesNamesList = getDriver().findElements(
+                By.xpath("//table[@id='category']/tbody/tr/td[1]/a")
+        );
+
+        //A3
+        Assert.assertTrue(languagesNamesList.size() > 0);
+
+        for (int i = 0; i < languagesNamesList.size(); i++) {
+            Assert.assertTrue(languagesNamesList.get(i).getText().toLowerCase().contains(LANGUAGE_PYTHON));
+        }
+    }
+}


### PR DESCRIPTION
testSearchForLanguageFieldByName_HappyPath() added

[US] - https://trello.com/c/gk73LnbY/48-usfunctionalsearchform-search-for-language-field
[TC] - https://trello.com/c/XeSkl5Aw/78-tcsearchform-verify-if-user-is-searching-for-programming-language-by-name-he-can-see-the-list-of-relative-results-andreimironau
[AT] - https://trello.com/c/fZKNVCIY/184-atsearchform-testsearchforlanguagefieldbynamehappypath-andreimironau