### PR TITLE
[AT][Search][form]testSearchForLanguageByName_HappyPath<Kot612005>

### DIFF
--- a/src/test/java/Kot612005Test.java
+++ b/src/test/java/Kot612005Test.java
@@ -1,0 +1,39 @@
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import runner.BaseTest;
+
+import java.util.List;
+
+
+public class Kot612005Test extends BaseTest {
+    @Test
+    public void testSearchForLanguageByName_HappyPath() {
+        final String BASE_URL = "https://www.99-bottles-of-beer.net/";
+        final String LANGUAGE_NAME = "python";
+
+        getDriver().get(BASE_URL);
+
+        WebElement searchLanguagesMenu = getDriver().findElement(
+                By.xpath("//ul[@id = 'menu']/li/a[@href = '/search.html']")
+        );
+        searchLanguagesMenu.click();
+
+        WebElement searchForField = getDriver().findElement(By.name("search"));
+        searchForField.click();
+        searchForField.sendKeys(LANGUAGE_NAME);
+
+        WebElement goButton = getDriver().findElement(By.name("submitsearch"));
+        goButton.click();
+
+        List<WebElement> languagesNamesList = getDriver().findElements(By.xpath("//table[@id='category']/tbody/tr/td[1]/a"));
+
+        Assert.assertTrue(languagesNamesList.size() > 0);
+
+        for (int i = 0; i < languagesNamesList.size(); i++) {
+            Assert.assertTrue(languagesNamesList.get(i).getText().toLowerCase().contains(LANGUAGE_NAME));
+        }
+    }
+
+}


### PR DESCRIPTION
testSearchForLanguageByName_HappyPath added

[US] - https://trello.com/c/KzRBItiq/168-usfunctionalsearchform-search-for-language-by-name
[TC] - https://trello.com/c/Qg73XGfR/180-tcsearchform-verify-if-user-is-searching-programming-language-by-name-he-can-see-the-list-of-relative-results-kot612005
[AT] - https://trello.com/c/iafiYr68/181-atsearchform-testsearchforlanguagebynamehappypathkot612005