### PR TITLE
[AT][Main][footer][toplist] testIfToplistsFooterMenRedirectsToPageWithInformation_WhenClickingOnIt <VictoriaLema>

### DIFF
--- a/src/test/java/VictoriaLemaTest.java
+++ b/src/test/java/VictoriaLemaTest.java
@@ -53,4 +53,23 @@ public class VictoriaLemaTest extends BaseTest {
 
         Assert.assertEquals(actualResult,expectedResult);
     }
+
+    @Test
+    public void testIfToplistsFooterMenRedirectsToPageWithInformation_WhenClickingOnIt() {
+        final int TOP_LANGUAGES_MINIMAL_QUANTITY = 2;
+        getDriver().get(BASE_URL);
+        WebElement topListsOnTheFooter = getDriver().findElement(
+                By.xpath("//div[@id='footer']/p/a[@href='/toplist.html']")
+        );
+        topListsOnTheFooter.click();
+
+        List <WebElement> topRatedLanguagesNames = getDriver().findElements(
+                By.xpath("//table[@id='category']/tbody/tr/td[2]")
+        );
+
+        Assert.assertTrue(topRatedLanguagesNames.size()>0);
+
+        Assert.assertTrue(topRatedLanguagesNames.size()>=TOP_LANGUAGES_MINIMAL_QUANTITY);
+
+    }
 }

--- a/src/test/java/VictoriaLemaTest.java
+++ b/src/test/java/VictoriaLemaTest.java
@@ -70,6 +70,5 @@ public class VictoriaLemaTest extends BaseTest {
         Assert.assertTrue(topRatedLanguagesNames.size()>0);
 
         Assert.assertTrue(topRatedLanguagesNames.size()>=TOP_LANGUAGES_MINIMAL_QUANTITY);
-
     }
 }


### PR DESCRIPTION
testIfToplistsFooterMenRedirectsToPageWithInformation_WhenClickingOnIt added

[US]-https://trello.com/c/AkkS2Fch/215-usmainfootertoplist-functionality-of-top-list-menu-on-footervictorialema
[TC]-https://trello.com/c/egR9vogF/234-tcmainfootertoplist-verify-if-user-can-see-the-table-of-top-rated-languages-with-information-using-the-footer-menu-victorialema
[AT]-https://trello.com/c/2ssDZ5TU/237-atmainfootertoplist-testiftoplistsfootermenredirectstopagewithinformationwhenclickingonit-victorialema