### PR TITLE
[AT][Search][form] testSearchLanguageByName_HappyPath() <katy1313>

### DIFF
--- a/src/test/java/Katy1313Test.java
+++ b/src/test/java/Katy1313Test.java
@@ -1,0 +1,38 @@
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import runner.BaseTest;
+
+import java.util.List;
+import java.util.Locale;
+
+public class Katy1313Test extends BaseTest {
+
+    @Test
+    public void testSearchLanguageByName_HappyPath() {
+        final String BASE_URL = "https://www.99-bottles-of-beer.net/";
+        final String LANGUAGE_NAME = "python";
+
+        getDriver().get(BASE_URL);
+        WebElement searchLanguagesMenu = getDriver().findElement(
+                By.xpath("//ul[@id = 'menu']/li/a[@href = '/search.html']")
+        );
+        searchLanguagesMenu.click();
+
+        WebElement searchForField = getDriver().findElement(By.name("search"));
+        searchForField.click();
+        searchForField.sendKeys(LANGUAGE_NAME);
+
+        WebElement goButton = getDriver().findElement(By.name("submitsearch"));
+        goButton.click();
+
+        List<WebElement> languagesNamesList = getDriver().findElements(By.xpath("//table[@id='category']/tbody/tr/td[1]/a"));
+
+        Assert.assertTrue(languagesNamesList.size() > 0);
+
+        for (int i = 0; i < languagesNamesList.size(); i++) {
+            Assert.assertTrue(languagesNamesList.get(i).getText().toLowerCase().contains(LANGUAGE_NAME));
+        }
+    }
+}


### PR DESCRIPTION
testSearchLanguageByName_HappyPath() added

[TC] - https://trello.com/c/cHa6Ao7R/160-tcsearchform-verify-that-the-user-is-able-to-search-for-a-programming-language-by-name-and-able-to-see-the-list-of-relative-resu
[AT] - https://trello.com/c/HKiFJpQV/162-atsearchform-testsearchlanguagebynamehappypath-katy1313