### PR TITLE
[AT][Main][footer][start]testClickOnStartInFooter_HappyPath<Kot612005>

### DIFF
--- a/src/test/java/Kot612005Test.java
+++ b/src/test/java/Kot612005Test.java
@@ -36,4 +36,21 @@ public class Kot612005Test extends BaseTest {
         }
     }
 
+
+    @Test
+    public void testClickOnStartInFooter_HappyPath(){
+        final String BASE_URL = "https://www.99-bottles-of-beer.net/";
+        String expectedResult = "https://www.99-bottles-of-beer.net/";
+
+        getDriver().get(BASE_URL);
+
+        WebElement searchStartInMenu = getDriver().findElement(
+                By.xpath("//div[@id='footer']//a[@href = '/']"));
+        searchStartInMenu.click();
+
+        String actualResult = getDriver().getCurrentUrl();
+
+        Assert.assertEquals(actualResult, expectedResult);
+
+    }
 }


### PR DESCRIPTION
testClickOnStartInFooter_HappyPath added

[US] https://trello.com/c/2186kyHh/238-usmainfooterstart-after-clicking-on-start-field-base-url-stays-the-samekot612005
[TC] https://trello.com/c/fPwnCAwN/233-tcmainfooterstart-after-clicking-on-start-field-base-url-stays-the-samekot612005
[AT] https://trello.com/c/19bCqUd1/235-atmainfooterstart-after-clicking-on-start-field-base-url-stays-the-samekot612005
