### PR TITLE
[AT][Search][form] testSearchForLanguageByName_HappyPath() <IrinaDud>

### DIFF
--- a/src/test/java/IrinaDud_Test.java
+++ b/src/test/java/IrinaDud_Test.java
@@ -1,0 +1,37 @@
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import runner.BaseTest;
+
+import java.util.List;
+
+public class IrinaDud_Test extends BaseTest {
+    @Test
+    public void testSearchForLanguageByName_HappyPath () {
+        final String BASE_URL = "https://www.99-bottles-of-beer.net/";
+        final String LANGUAGE_NAME = "python";
+
+        getDriver().get(BASE_URL);
+
+        WebElement searchLanguagesMenu = getDriver().findElement(
+                By.xpath("//ul[@id='menu']/li/a[@href='/search.html']")
+        );
+        searchLanguagesMenu.click();
+
+        WebElement searchForField = getDriver().findElement(By.name("search"));
+        searchForField.click();
+        searchForField.sendKeys(LANGUAGE_NAME);
+
+        WebElement goButton = getDriver().findElement(By.name("submitsearch"));
+        goButton.click();
+
+        List<WebElement> languagesNamesList = getDriver().findElements(By.xpath("//table[@id='category']/tbody/tr/td[1]/a"));
+
+        Assert.assertTrue(languagesNamesList.size() > 0);
+
+        for(int i = 0;i < languagesNamesList.size();i ++) {
+            Assert.assertTrue(languagesNamesList.get(i).getText().toLowerCase().contains(LANGUAGE_NAME));
+        }
+    }
+}


### PR DESCRIPTION
testSearchForLanguageByName_HappyPath() added

[US]-https://trello.com/c/72sUwOoc/295-usfunctionalsearchform-search-for-language-field
[TC]-https://trello.com/c/0i03EqBJ/299-tcsearchform-verify-if-user-is-searching-for-programming-language-by-name-he-can-see-the-list-of-relative-results-irinadud
[AT]-https://trello.com/c/6gg9Dh3V/301-atsearchform-testsearchforlanguagebynamehappypath-irinadud