### PR TITLE
[AT][Main][navigation][menu][start] on the 'START' page user should be able to read the 'Welcome to 99 Bottles of Beer' header <MariaYanu>

### DIFF
--- a/src/test/java/MariaYanuTest.java
+++ b/src/test/java/MariaYanuTest.java
@@ -1,0 +1,29 @@
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import runner.BaseTest;
+
+public class MariaYanuTest extends BaseTest {
+    @Test
+    public void testHeaderOnTheStartPage() {
+        final String BASE_URL = "https://www.99-bottles-of-beer.net/";
+        final String START_URL = "https://www.99-bottles-of-beer.net/";
+        final String HEADER_TEXT = "Welcome to 99 Bottles of Beer";
+
+        getDriver().get(BASE_URL);
+
+        WebElement startLink = getDriver().findElement(
+                By.xpath("//div[@id='navigation']//a[text()='Start']")
+        );
+        startLink.click();
+
+        Assert.assertEquals(getDriver().getCurrentUrl(),START_URL);
+
+        WebElement header = getDriver().findElement(
+                By.xpath("//div[@id='main']//h2")
+        );
+
+        Assert.assertEquals(header.getText(), HEADER_TEXT);
+    }
+}


### PR DESCRIPTION
testHeaderOnTheStartPage() added
US:https://trello.com/c/09n8333z/287-usmainnavigationmenustart-after-clicking-on-start-in-the-navigation-menu-a-user-will-see-the-welcome-to-99-bottles-of-beer-heade
TC: https://trello.com/c/pNB1b5Z6/293-tcmainnavigationmenustart-on-the-start-page-user-should-be-able-to-read-the-welcome-to-99-bottles-of-beer-header-mariayanu
AT: https://trello.com/c/YgWU3FT5/352-atmainnavigationmenustart-on-the-start-page-user-should-be-able-to-read-the-welcome-to-99-bottles-of-beer-header-mariayanu