### PR TITLE
[AT][B][main][header][h2] testHeaderH2Text_WhenOpenBrowseLanguageMenu_PageBSubmenu_HappyPath() <Nstzya>

### DIFF
--- a/src/test/java/NstzyaTest.java
+++ b/src/test/java/NstzyaTest.java
@@ -23,6 +23,10 @@ public class NstzyaTest extends BaseTest {
 
     final static By MAIN = By.xpath("//div[@id='main']");
 
+    final static By BROWSE_LANGUAGES_MENU = By.xpath("//div[@id='navigation']/ul/li/a[@href='/abc.html']");
+    final static By B_SUBMENU = By.xpath("//ul[@id='submenu']/li/a[@href='b.html']");
+    final static By HEADER_H2_ON_PAGE_B_SUBMENU = By.xpath("//div[@id='main']/h2[contains(text(), 'Category B')]");
+
 
     private void openBaseURL(WebDriver driver) {
         driver.get(BASE_URL);
@@ -69,6 +73,11 @@ public class NstzyaTest extends BaseTest {
 
     private void isDisplayed(By by, WebDriver driver) {
         getElement(by, driver).isDisplayed();
+    }
+
+    private String getTextOfWebElement(By by, WebDriver driver) {
+
+        return getElement(by, driver).getText();
     }
 
 
@@ -127,5 +136,20 @@ public class NstzyaTest extends BaseTest {
         click(TEAM_MEMBERS_URL, getDriver());
         String actualResult5 = getCurrentUrl(getDriver());
         Assert.assertEquals(actualResult5, expectedResult5);
+    }
+
+
+    @Test
+    public void testHeaderH2Text_WhenOpenBrowseLanguageMenu_PageBSubmenu_HappyPath() {
+
+        String expectedResult = "Category B";
+
+        openBaseURL(getDriver());
+        click(BROWSE_LANGUAGES_MENU, getDriver());
+        click(B_SUBMENU, getDriver());
+
+        String actualResult = getTextOfWebElement(HEADER_H2_ON_PAGE_B_SUBMENU, getDriver());
+
+        Assert.assertEquals(actualResult, expectedResult);
     }
 }


### PR DESCRIPTION
testHeaderH2Text_WhenOpenBrowseLanguageMenu_PageBSubmenu_HappyPath() added

[US] - https://trello.com/c/pWfjZS54/520-usbmainheaderh2-verify-header-h2-in-tab-browse-language-of-menu-and-page-b-of-submenu
[TC] - https://trello.com/c/pTGxYUTC/521-tcbmainheaderh2-verify-header-h2-in-tab-browse-language-page-b-nstzya
[AT] - https://trello.com/c/sOCbXFG8/522-atbmainheaderh2-testheaderh2textwhenopenbrowselanguagemenupagebsubmenuhappypath-nstzya