### PR TITLE
[AT][J][main][table][link] testRandomLinkIsClickable_whenOpenBrowseLanguageMenu_JSubmenu_HappyPath <Nstzya>

### DIFF
--- a/src/test/java/NstzyaTest.java
+++ b/src/test/java/NstzyaTest.java
@@ -1,6 +1,8 @@
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import runner.BaseTest;
@@ -160,6 +162,8 @@ public class NstzyaTest extends BaseTest {
     @Test
     public void testRandomLinkIsClickable_whenOpenBrowseLanguageMenu_JSubmenu_HappyPath() {
 
+        char expectedResult = 'j';
+
         openBaseURL(getDriver());
         click(BROWSE_LANGUAGES_MENU, getDriver());
         click(J_SUBMENU, getDriver());
@@ -171,6 +175,9 @@ public class NstzyaTest extends BaseTest {
         List<WebElement> languageNamesStartWithJLinks = getListOfElements(LANGUAGES_NAMES_STARTED_WITH_J_LIST, getDriver());
 
         WebElement randomLink = languageNamesStartWithJLinks.get(r.nextInt(languageNamesStartWithJLinks.size()));
+
+        Assert.assertEquals(randomLink.getText().toLowerCase().charAt(0), expectedResult);
+
         randomLink.click();
     }
 }

--- a/src/test/java/NstzyaTest.java
+++ b/src/test/java/NstzyaTest.java
@@ -7,6 +7,7 @@ import runner.BaseTest;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 
 public class NstzyaTest extends BaseTest {
     final String BASE_URL = "https://www.99-bottles-of-beer.net/";
@@ -27,6 +28,8 @@ public class NstzyaTest extends BaseTest {
     final static By B_SUBMENU = By.xpath("//ul[@id='submenu']/li/a[@href='b.html']");
     final static By HEADER_H2_ON_PAGE_B_SUBMENU = By.xpath("//div[@id='main']/h2[contains(text(), 'Category B')]");
 
+    final static By J_SUBMENU = By.xpath("//div[@id='navigation']/ul/li/a[@href='j.html']");
+    final static By LANGUAGES_NAMES_STARTED_WITH_J_LIST = By.xpath("//table[@id='category']/tbody/tr/td[1]/a");
 
     private void openBaseURL(WebDriver driver) {
         driver.get(BASE_URL);
@@ -151,5 +154,23 @@ public class NstzyaTest extends BaseTest {
         String actualResult = getTextOfWebElement(HEADER_H2_ON_PAGE_B_SUBMENU, getDriver());
 
         Assert.assertEquals(actualResult, expectedResult);
+    }
+
+
+    @Test
+    public void testRandomLinkIsClickable_whenOpenBrowseLanguageMenu_JSubmenu_HappyPath() {
+
+        openBaseURL(getDriver());
+        click(BROWSE_LANGUAGES_MENU, getDriver());
+        click(J_SUBMENU, getDriver());
+
+        List<String> languagesNamesStartWIthJ = getElementsText(LANGUAGES_NAMES_STARTED_WITH_J_LIST, getDriver());
+        Assert.assertTrue(languagesNamesStartWIthJ.size() > 0);
+
+        Random r = new java.util.Random();
+        List<WebElement> languageNamesStartWithJLinks = getListOfElements(LANGUAGES_NAMES_STARTED_WITH_J_LIST, getDriver());
+
+        WebElement randomLink = languageNamesStartWithJLinks.get(r.nextInt(languageNamesStartWithJLinks.size()));
+        randomLink.click();
     }
 }


### PR DESCRIPTION
testRandomLinkIsClickable_whenOpenBrowseLanguageMenu_JSubmenu_HappyPath() added

[US] - https://trello.com/c/MMiUJpb8/551-usjmaintablelink-verify-random-link-in-table-is-clickable-when-open-browse-language-in-menu-and-j-in-submenu
[TC] - https://trello.com/c/DmuXvssQ/552-tcjmaintablelink-verify-random-link-in-table-is-clickable-when-open-browse-language-in-menu-and-j-in-submenu-nstzya
[AT] - https://trello.com/c/pCGvFT41/553-atjmaintablelink-testrandomlinkisclickablewhenopenbrowselanguagemenujsubmenuhappypath-nstzya