### PR TITLE
[AT][Main][header][h2] Verify the header h2 on the start page <ElenaStrat>

### DIFF
--- a/src/test/java/ElenaStratTest.java
+++ b/src/test/java/ElenaStratTest.java
@@ -105,4 +105,19 @@ public class ElenaStratTest extends BaseTest {
     }
 
 
+
+    @Test
+    public void testMainForVerifyTheHeaderH2OnTheStartPage_HappyPath() {
+        String expectedResult = "one program in 1500 variations";
+
+        openBaseURL(getDriver());
+
+        WebElement verifyHeaderH1 = getDriver().findElement(By.xpath("//div[@id = 'header']/h2"));
+
+        String actualResult = verifyHeaderH1.getText();
+
+        Assert.assertEquals(actualResult,expectedResult);
+    }
+
+
 }


### PR DESCRIPTION
test for verify the header h2 on the start page added

[US] https://trello.com/c/VHjZoIlg/592-usfunctionalheaderh2-verify-the-header-h2-on-the-start-page 
[TC] https://trello.com/c/nHEp9qGB/593-tcmainheaderh2-verify-the-header-h2-on-the-start-page-elenastrat
[AT] https://trello.com/c/cHVg9AS9/594-atmainheaderh2-verify-the-header-h2-on-the-start-page-elenastrat 