### PR TITLE
[AT][ABC][navigation][submenu][n] testLinkText_WhenNavigatingFromStartToBrowseLanguageAndToLetterNLink_HappyPath <Nstzya>

### DIFF
--- a/src/test/java/old_tests/NstzyaTest.java
+++ b/src/test/java/old_tests/NstzyaTest.java
@@ -33,6 +33,8 @@ public class NstzyaTest extends BaseTest {
     final static By J_SUBMENU = By.xpath("//div[@id='navigation']/ul/li/a[@href='j.html']");
     final static By LANGUAGES_NAMES_STARTED_WITH_J_LIST = By.xpath("//table[@id='category']/tbody/tr/td[1]/a");
 
+    final static By N_SUBMENU = By.xpath("//div[@id='navigation']/ul/li/a[@href='n.html']");
+
     private void openBaseURL(WebDriver driver) {
         driver.get(BASE_URL);
     }
@@ -179,5 +181,18 @@ public class NstzyaTest extends BaseTest {
         Assert.assertEquals(randomLink.getText().toLowerCase().charAt(0), expectedResult);
 
         randomLink.click();
+    }
+
+
+    @Test
+    public void testLinkText_WhenNavigatingFromStartToBrowseLanguageAndToLetterNLink_HappyPath() {
+
+        String expectedText = "N";
+
+        openBaseURL(getDriver());
+        click(BROWSE_LANGUAGES_MENU, getDriver());
+        click(N_SUBMENU, getDriver());
+
+        Assert.assertEquals(getElement(N_SUBMENU, getDriver()).getText(), expectedText);
     }
 }


### PR DESCRIPTION
testLinkText_WhenNavigatingFromStartToBrowseLanguageAndToLetterNLink_HappyPath() added

[US] - https://trello.com/c/qUba0ugY/611-usabcnavigationsubmenun-verify-text-in-the-link-when-open-browse-language-and-then-letter-n-links
[TC] - https://trello.com/c/PJCzOhZy/613-tcabcnavigationsubmenun-verify-text-in-the-header-h2-and-in-the-link-when-open-browse-language-and-then-letter-n-links-nstzya
[AT] - https://trello.com/c/lNTInU8A/614-atabcnavigationsubmenun-testlinktextwhennavigatingfromstarttobrowselanguageandtoletternlinkhappypath-nstzya