### PR TITLE
[AT][POM][ABC][navigation][submenu][k] testAllLanguagesOnKPageBeginWithLetterK <NatalliaOwl>

### DIFF
--- a/src/test/java/pages/BrowseLanguagesSubmenuPage.java
+++ b/src/test/java/pages/BrowseLanguagesSubmenuPage.java
@@ -39,6 +39,9 @@ public abstract class BrowseLanguagesSubmenuPage extends TablePage {
     @FindBy(xpath = "//div[@id = 'navigation']/ul[@id = 'submenu']/li/a[@href]")
     private List<WebElement> symbolInSubmenu;
 
+    @FindBy(xpath = "//ul[@id = 'submenu']//a[@href = 'k.html']")
+    private WebElement kSubmenu;
+
     public BrowseLanguagesSubmenuPage(WebDriver driver) {
         super(driver);
     }
@@ -188,5 +191,11 @@ public abstract class BrowseLanguagesSubmenuPage extends TablePage {
             }
         }
         return null;
+    }
+
+    public KPage clickKSubmenu() {
+        click(cSubmenu);
+
+        return new KPage(getDriver());
     }
 }

--- a/src/test/java/pages/BrowseLanguagesSubmenuPage.java
+++ b/src/test/java/pages/BrowseLanguagesSubmenuPage.java
@@ -194,7 +194,7 @@ public abstract class BrowseLanguagesSubmenuPage extends TablePage {
     }
 
     public KPage clickKSubmenu() {
-        click(cSubmenu);
+        click(kSubmenu);
 
         return new KPage(getDriver());
     }

--- a/src/test/java/tests/KTest.java
+++ b/src/test/java/tests/KTest.java
@@ -4,6 +4,8 @@ import base.BaseTest;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.util.List;
+
 public class KTest extends BaseTest {
 
     @Test
@@ -18,5 +20,21 @@ public class KTest extends BaseTest {
 
         Assert.assertEquals(getExternalPageTitle(), expectedResultTitle);
         Assert.assertEquals(getExternalPageURL(), expectedResultCurrentUrl);
+    }
+
+    @Test
+    public void testAllLanguagesNamesOnKPageStartWithLetterK() {
+        final String FIRST_LETTER = "K";
+
+        List<String> languagesNamesInUpperCase = openBaseURL()
+                .clickBrowseLanguagesMenu()
+                .clickKSubmenu()
+                .getNamesInUpperCase();
+
+        Assert.assertTrue(languagesNamesInUpperCase.size() > 0);
+
+        for (String languageName : languagesNamesInUpperCase) {
+            Assert.assertEquals(languageName.toUpperCase().substring(0, 1), FIRST_LETTER);
+        }
     }
 }


### PR DESCRIPTION
testAllLanguagesNamesOnKPageStartWithLetterK() created,
Webelement and method added to BrowseLanguageSubmenuPage

[AT] - https://trello.com/c/d38s1NR4/666-atpomabcnavigationsubmenuk-testalllanguagesonkpagebeginwithletterk-natalliaowl