### PR TITLE
[AT][LanguageJavascript1948][main][table][link] testJSDeepLinkText() <verafes>

### DIFF
--- a/src/test/java/pages/base_abstract/TablePage.java
+++ b/src/test/java/pages/base_abstract/TablePage.java
@@ -29,6 +29,9 @@ public abstract class TablePage extends MainPage {
     @FindBy(xpath = "//*[@id='main']/table/tbody//td[2]")
     private List<WebElement> tableListValues;
 
+    @FindBy(xpath = "//*[@id='main']//a[contains(text(),'http://en.wikipedia.org/wiki/Javascript')]")
+    private WebElement tableDeepLink;
+
     public TablePage(WebDriver driver) {
         super(driver);
     }
@@ -111,5 +114,10 @@ public abstract class TablePage extends MainPage {
     public List<String> getTableListValues(){
 
         return getListText(tableListValues);
+    }
+
+    public String getHrefDeepLink(String attribute) {
+
+        return getAttribute(tableDeepLink, "href");
     }
 }

--- a/src/test/java/pages/base_abstract/TablePage.java
+++ b/src/test/java/pages/base_abstract/TablePage.java
@@ -137,4 +137,5 @@ public abstract class TablePage extends MainPage {
     public String getHrefDeepLink(String attribute) {
 
         return getAttribute(tableDeepLink, "href");
+    }
 }

--- a/src/test/java/tests/JavaScriptLanguageTest.java
+++ b/src/test/java/tests/JavaScriptLanguageTest.java
@@ -12,7 +12,7 @@ import java.util.List;
 public class JavaScriptLanguageTest extends BaseTest {
 
     @Test
-    public void testJavaLanguagePageHeader() {
+    public void testJavaScriptLanguagePageHeader() {
         String EXPECTED_JS_H2_HEADER = "Language JavaScript";
 
         String actualJSH2Header = openBaseURL()
@@ -57,4 +57,19 @@ public class JavaScriptLanguageTest extends BaseTest {
         Assert.assertEquals(actualListValues, expectedListValues);
     }
 
+    @Test
+    public void testJSDeepLinkText() {
+
+        final String attribute = "href";
+        final String expectedDeepLink = "http://en.wikipedia.org/wiki/Javascript";
+
+        String actualDeepLink =
+                openBaseURL()
+                        .clickBrowseLanguagesMenu()
+                        .clickJSubmenu()
+                        .clickJavaScriptLink()
+                        .getHrefDeepLink(attribute);
+
+        Assert.assertEquals(actualDeepLink, expectedDeepLink);
+    }
 }


### PR DESCRIPTION
testJSDeepLinkText() added

(the deep link text is hyperlinked)

[AT] https://trello.com/c/O9ghltC5/736-atlanguagejavascript1948maintablelink-testjsdeeplinktext-verafes
[TC] https://trello.com/c/8xBbqp7N/737-tcpomlanguagejavascript1948maintablelink-verify-js-deep-link-href-text-verafes