### PR TITLE
[AT][LanguageJavascript1948][main][table][link] testJavaScriptDeeLink_NavigatesTo_CorrespondingPage() <verafes>

### DIFF
--- a/src/test/java/pages/base_abstract/TablePage.java
+++ b/src/test/java/pages/base_abstract/TablePage.java
@@ -34,7 +34,7 @@ public abstract class TablePage extends MainPage {
     @FindBy(tagName = "a")
     private List<String> tableLinksList;
 
-    @FindBy(xpath = "//*[@id='main']//a[contains(text(),'http://en.wikipedia.org/wiki/Javascript')]")
+    @FindBy(xpath = "//*[@id='main']/table/tbody/tr[5]/td[2]/a")
     private WebElement tableDeepLink;
 
     @FindBy(xpath = "//div[@id='main']//tbody//td[4]")

--- a/src/test/java/pages/browse_languages/languages/JavaScriptLanguagePage.java
+++ b/src/test/java/pages/browse_languages/languages/JavaScriptLanguagePage.java
@@ -7,7 +7,16 @@ import pages.base_abstract.BasePage;
 
 public class JavaScriptLanguagePage extends LanguagePage {
 
+    @FindBy(xpath = "//*[@id='main']//a[contains(text(), 'http://en.wikipedia.org/wiki/Javascript')]")
+    private WebElement JavaScriptDeepLink;
+
     public JavaScriptLanguagePage(WebDriver driver) {
         super(driver);
+    }
+
+    public JavaScriptLanguagePage clickJavaScriptDeepLink() {
+        click(JavaScriptDeepLink);
+
+        return new JavaScriptLanguagePage(getDriver());
     }
 }

--- a/src/test/java/tests/JavaScriptLanguageTest.java
+++ b/src/test/java/tests/JavaScriptLanguageTest.java
@@ -4,6 +4,7 @@ import base.BaseTest;
 import org.openqa.selenium.By;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+import pages.browse_languages.languages.JavaScriptLanguagePage;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -71,5 +72,25 @@ public class JavaScriptLanguageTest extends BaseTest {
                         .getHrefDeepLink(attribute);
 
         Assert.assertEquals(actualDeepLink, expectedDeepLink);
+    }
+
+    @Test
+    public void testJavaScriptDeeLink_NavigatesTo_CorrespondingPage() {
+        final String expectedExternalURL = "https://en.wikipedia.org/wiki/JavaScript";
+        final String expectedExternalTitle = "JavaScript - Wikipedia";
+
+        String oldJSLanguagePageURL = openBaseURL()
+                .clickBrowseLanguagesMenu()
+                .clickJSubmenu()
+                .clickJavaScriptLink()
+                .getURL();
+
+        JavaScriptLanguagePage javaScriptLanguagePage = new JavaScriptLanguagePage(getDriver());
+
+        javaScriptLanguagePage.clickJavaScriptDeepLink();
+
+        Assert.assertNotEquals(oldJSLanguagePageURL, getExternalPageURL());
+        Assert.assertEquals(getExternalPageURL(), expectedExternalURL);
+        Assert.assertEquals(getExternalPageTitle(), expectedExternalTitle);
     }
 }


### PR DESCRIPTION
testJavaScriptDeeLink_NavigatesTo_CorrespondingPage() added, 

TablePage: xpath fixed

[TC] - https://trello.com/c/AconBuLV/750-tcpomlanguagejavascript1948maintablelink-js-deep-link-navigates-to-external-page-verafes
[AT] - https://trello.com/c/bZ7iMhRh/751-atlanguagejavascript1948maintablelink-testjavascriptdeelinknavigatestocorrespondingexternalpage-verafes 