### PR TITLE
[AT][API][ABC][navigation][submenu][J] test_API_AllJLinksAndImagesAreNotBroken <verafes> 

### DIFF
--- a/src/test/java/tests/api/API_JTest.java
+++ b/src/test/java/tests/api/API_JTest.java
@@ -2,10 +2,16 @@ package tests.api;
 
 import base.BaseTest;
 import network.CaptureNetworkTraffic;
+import org.openqa.selenium.WebElement;
 import org.testng.Assert;
+import org.testng.Reporter;
 import org.testng.annotations.Test;
 import pages.browse_languages.letters.JPage;
+import pages.top_lists.TopRatedRealPage;
 
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
 import java.util.List;
 
 public class API_JTest  extends BaseTest  {
@@ -80,5 +86,89 @@ public class API_JTest  extends BaseTest  {
         Assert.assertEquals(httpResponse.get(1), expectedStatusText);
         Assert.assertEquals(httpResponse.get(2), getBaseUrl() + expectedEndPoint);
         Assert.assertTrue(Double.parseDouble(httpResponse.get(3).substring(10, 14)) <= expectedResponseTimeStandard);
+    }
+
+    @Test
+    public void test_API_AllJLinksAreNotBroken () {
+        String linkURL = "";
+        int responseCode;
+        int actualWorkingLinksCount = 0;
+
+        List<WebElement> aTags = openBaseURL()
+                .clickBrowseLanguagesMenu()
+                .clickJSubmenu()
+                .getLinks();
+
+        final int expectedWorkingLinksCount = aTags.size();
+        int internalLinks = expectedWorkingLinksCount;
+
+        for (WebElement link : aTags) {
+            linkURL = link.getAttribute("href");
+
+            if (linkURL != null && !linkURL.isBlank() && !linkURL.isEmpty()) {
+                if (!linkURL.startsWith(getBaseUrl())) {
+                    Reporter.log(linkURL + " is externalLink ", true);
+                    internalLinks--;
+                } else {
+                    try {
+                        HttpURLConnection connection = (HttpURLConnection) (new URL(linkURL).openConnection());
+                        connection.setRequestMethod("HEAD");
+                        connection.connect();
+
+                        responseCode = connection.getResponseCode();
+
+                        if (responseCode < 400) {
+                            actualWorkingLinksCount++;
+                        } else {
+                            Reporter.log(linkURL + " is broken, responseCode " + responseCode, true);
+                        }
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                    }
+                }
+            }
+        }
+
+        Assert.assertEquals(actualWorkingLinksCount, internalLinks);
+        Assert.assertEquals(actualWorkingLinksCount, expectedWorkingLinksCount);
+    }
+
+    @Test
+    public void test_API_AllImagesAreNotBroken() {
+        String imageURL = "";
+        int responseCode;
+        int actualWorkingImagesCount = 0;
+        TopRatedRealPage topRatedRealPage = new TopRatedRealPage(getDriver());
+
+        List<WebElement> imgTags = openBaseURL()
+                .clickBrowseLanguagesMenu()
+                .clickJSubmenu()
+                .getImages();
+
+        final int expectedWorkingImagesCount = imgTags.size();
+
+        for (WebElement image : imgTags) {
+            imageURL = image.getAttribute("src");
+
+            if (imageURL != null && !imageURL.isBlank() && !imageURL.isEmpty()) {
+                try {
+                    HttpURLConnection connection = (HttpURLConnection) (new URL(imageURL).openConnection());
+                    connection.connect();
+
+                    responseCode = connection.getResponseCode();
+
+                    if (responseCode < 400 && topRatedRealPage.isImageDisplayed(image)) {
+                        actualWorkingImagesCount++;
+                    } else {
+                        Reporter.log(imageURL + " is broken, responseCode " + responseCode
+                                + "OR image not displayed", true);
+                    }
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+
+        Assert.assertEquals(actualWorkingImagesCount, expectedWorkingImagesCount);
     }
 }


### PR DESCRIPTION
Test_API_AllJLinksAreNotBroken() and test_API_AllImagesAreNotBroken() on J page are added

[AT] -https://trello.com/c/s0gwakoP/793-atapiabcnavigationsubmenuj-testapihttpresponselinksverafes